### PR TITLE
Removing unused dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,13 @@ to support the decentralized web.
 git clone https://git@github.com/internetarchive/dweb-archivecontroller.git
 cd dweb-archivecontroller
 
-# install the dependencies including IPFS & WebTorrent and dweb-transports and dweb-objects
-npm install  
+# install the dependencies including IPFS & WebTorrent
+npm install
+
+# NOTE:
+# dweb-transports - will be provided to client using window.DwebTransports in a separate import
+# dweb-objects - will be provided to client using window.DwebObjects in a separate import
+
 ```
 
 ### Node Installation to work on this repo

--- a/package.json
+++ b/package.json
@@ -10,8 +10,6 @@
   "description": "Archive UI to run in Browser",
   "dependencies": {
     "@babel/core": "^7.2.2",
-    "@internetarchive/dweb-objects": "^0.1.20",
-    "@internetarchive/dweb-transports": "^0.1.30",
     "@stratumn/canonicaljson": "^1.0.2",
     "async": "^2.6.2",
     "debug": "^4.1.1",


### PR DESCRIPTION
`dweb-transports` and `dweb-objects` are available on the browser via the `window` object.  This attachment is created from a side effect of another import

This change also helps the integration of `@internetarchive/ia-components` into internal Petabox

This fixes https://github.com/internetarchive/iaux/issues/153